### PR TITLE
Cursor session closing bug

### DIFF
--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -376,8 +376,6 @@ class Cursor:
     @check_closed
     def close(self):
         """Close the cursor."""
-        if self.session is not None and not self.session.is_closed:
-            self.session.close()
         self.closed = True
 
     def is_valid_exception(self, e):
@@ -652,7 +650,6 @@ class AsyncCursor(Cursor):
     @check_closed
     async def close(self):
         """Close the cursor."""
-        await self.session.aclose()
         self.closed = True
 
 

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -92,6 +92,14 @@ class ConnectionTest(TestCase):
 
         self.assertIsNot(session1, session2)
 
+    def test_cursor_doesnt_close_session_for_other_cursors(self):
+        connection = db.Connection(host='localhost')
+        cursor1 = connection.cursor()
+        cursor2 = connection.cursor()
+        cursor1.close()
+
+        self.assertFalse(cursor2.session.is_closed)
+
     def test_starts_not_closed(self):
         connection = db.Connection(
             host='localhost', session=MagicMock(spec=httpx.Client))
@@ -236,6 +244,14 @@ class AsyncConnectionTest(IsolatedAsyncioTestCase):
 
         self.assertTrue(cursor.closed)
 
+    async def test_cursor_doesnt_close_session_for_other_cursors(self):
+        connection = db.AsyncConnection(host='localhost')
+        cursor1 = connection.cursor()
+        cursor2 = connection.cursor()
+        await cursor1.close()
+
+        self.assertFalse(cursor2.session.is_closed)
+
     async def test_renews_session_if_closed_when_getting_cursor(self):
         connection = db.AsyncConnection(host='localhost')
         connection.cursor()
@@ -378,12 +394,12 @@ class CursorTest(TestCase):
         with self.assertRaises(exceptions.Error):
             cursor.close()
 
-    def test_closes_underlying_session_as_well(self):
+    def test_doesnt_close_underlying_session_as_well(self):
         cursor = db.Cursor(host='localhost', session=httpx.Client())
 
         cursor.close()
 
-        self.assertTrue(cursor.session.is_closed)
+        self.assertFalse(cursor.session.is_closed)
 
     def test_bypasses_session_close_if_already_closed(self):
         cursor = db.Cursor(host='localhost', session=httpx.Client())


### PR DESCRIPTION
Stopped `Cursor`'s/`AsyncCursor`'s closing underlying `httpx` sessions that are managed at the `Connection`/`AsyncConnection` level to prevent an active `Cursor` created before another calls `close()` having its shared `session` closed whilst its still being used. 

Added tests to catch this issue and demontrate its correctness.

Error scenario:
```
conn = Connection(...)
cursor1 = conn.cursor()
cursor2 = conn.cursor()
cursor1.execute(...)
cursor1.close()
cursor2.execute(...)  # Will fail due to close httpx session that can only be reopened in the Connection object
```

This PR fixes one bug mentioned in this issue: https://github.com/startreedata/pinot-dbapi/issues/226
